### PR TITLE
Merge pull request - development v1.1.1 to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ Alternatively, the user can set a global, project-independent quick export direc
 
 Suppose the user wishes to remove any references to an intermediate directory in the project. In that case, the user can click the "Delete quick export attributes from scenes" in the "General" tab of the plugin preferences.
 
-#### FBX Export Settings
+#### Quick Export Settings
 
-The user can customize how the asset gets exported under the "FBX Exporter" tab of the plugin preferences. The user can pick the native FBX exporter or a custom implementation in the "Exporter Type" dropdown.
+The user can customize how the asset gets exported under the "Quick Export" tab of the plugin preferences. The user can pick the native FBX exporter or a custom implementation in the "Exporter Type" dropdown.
+
+#### Quick Export Name Collection
+
+The "Quick Export Name Collection" feature allows the user to export wired objects that begin, end, or have an occurrence of a string in their name. This name collection feature can be helpful when exporting collision objects with a mesh without having to tick "Export Wired" for quick exports. The "Quick Export Name Collection" feature is under the "Quick Export" tab in the addon properties.
 
 ### Auto/Advanced Renaming
 ![AB_Blender_Utilities_Preferences_Naming_Tab_v1 1 0](https://github.com/ArtemyBelzer/AB-Blender-Utilities/assets/143417950/706b1a21-0456-4041-ae09-80352360d325)

--- a/ab_blender_utilities/__init__.py
+++ b/ab_blender_utilities/__init__.py
@@ -21,7 +21,7 @@ bl_info = {
     "location" : "Object Menu, Search, or Shortcuts (Default keymap for pie menu 'Alt+E')",
     "category" : "Utility",
     "doc_url" : "https://github.com/ArtemyBelzer",
-    "version" : (1, 1, 0)
+    "version" : (1, 1, 1)
 }
 
 if "ab_core" in locals():

--- a/ab_blender_utilities/addon/ab_constants.py
+++ b/ab_blender_utilities/addon/ab_constants.py
@@ -33,14 +33,23 @@ bake_suffixes : Final[tuple[str]] = ("_high", "_low", "_High", "_Low")
 block_types : Final[tuple[str]] = ("meshes", "materials", "textures", "images")
 
 # Preference tabs
-e_pref_tab : Final[tuple[tuple]]= (('GENERAL', "General", ""),
+e_pref_tab : Final[tuple[tuple]] = (('GENERAL', "General", ""),
                                    ('NAMING', "Naming", ""),
                                    ('KEYS', "Keybindings", ""),
                                    ('QUICK_EXPORT', "Quick Export", ""),
                                    ('ADVANCED', "Advanced", ""))
 
+# String find action
+e_string_find_action : Final[tuple[tuple]] = (('CONTAINS', "Contains", ""),
+                                              ('BEGINS_WITH', "Begins with", ""),
+                                              ('ENDS_WITH', "Ends with", ""))
+
+# Add/Remove enum
+e_add_remove : Final[tuple[tuple]] = (('ADD', "Add", ""),
+                                      ('REMOVE', "Remove", ""))
+
 # Preference tabs
-e_pref_display_tab : Final[tuple[tuple]]= (('SUBMENUS', "Menus", ""),
+e_pref_display_tab : Final[tuple[tuple]] = (('SUBMENUS', "Menus", ""),
                                            ('PANELS', "Panels", ""),
                                            ('SUBMENU_BUTTONS', "Button Menus", ""),
                                            ('PANELS_IN_PROPERTIES', "Property Panel", ""))
@@ -62,3 +71,6 @@ input_classes_none : Final[str] = "The input classes are missing. (NoneType)"
 # Prefs
 prefs_keymap_do_not_remove_msg : Final[str] = "Please do not remove the keymaps."
 prefs_keymap_disable_msg : Final[str] = "Disable them instead by unchecking the box on the left."
+
+restore_selection_description : Final[str] = "Restores the selection before quick exporting.\nIf unchecked, the current selection will be the final export object and its children."
+export_wired_description : Final[str] = "Export objects that have the 'Wired' display type."

--- a/ab_blender_utilities/addon/ab_core.py
+++ b/ab_blender_utilities/addon/ab_core.py
@@ -19,6 +19,7 @@ import traceback
 import sys
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from types import ModuleType
+from typing import Final
 from . import ab_constants, ab_debug, ab_keymaps, ab_op_menus, ab_op_panels, ab_persistent, ab_prefs
 from .. import operators
 
@@ -28,6 +29,14 @@ __exporters : list[ExportHelper] = []
 __importers : list[ImportHelper] = []
 __preferences : list[bpy.props.PointerProperty] = []
 __properties : list[bpy.types.PropertyGroup] = []
+
+__preference_classes : Final[tuple[bpy.types.AddonPreferences|
+                             bpy.types.PropertyGroup|
+                             bpy.types.UIList]] = (ab_prefs.PanelVars,
+                                                  ab_prefs.ABUTIL_UL_name_slots,
+                                                  ab_prefs.ABUtilQuickExportNames,
+                                                  ab_prefs.ABUtilAddonPrefs)
+
 
 def __clear_vars() -> None:
     """Clear variables that store pointers to references to classes."""
@@ -44,8 +53,8 @@ def register():
     
     # Addon preference class
     try:
-        bpy.utils.register_class(ab_prefs.PanelVars)
-        bpy.utils.register_class(ab_prefs.ABUtilAddonPrefs)
+        for pref_cls in __preference_classes:
+            bpy.utils.register_class(pref_cls)
     except Exception as e:
             print(f"{ab_constants.error} Error registering preferences {e}")
     
@@ -110,8 +119,6 @@ def register():
 
 def unregister():
     global __classes, __exporters, __importers, __preferences, __properties
-
-    # Unload menus and panels.
     ab_op_menus.unload()
     ab_op_panels.unload()
     
@@ -140,8 +147,8 @@ def unregister():
 
     # Addon preference class
     try:
-        bpy.utils.unregister_class(ab_prefs.ABUtilAddonPrefs)
-        bpy.utils.unregister_class(ab_prefs.PanelVars)
+        for pref_cls in __preference_classes:
+            bpy.utils.unregister_class(pref_cls)
     except Exception as e:
             print(f"{ab_constants.error} Error unregistering preferences {e}")
 

--- a/ab_blender_utilities/addon/ab_prefs.py
+++ b/ab_blender_utilities/addon/ab_prefs.py
@@ -576,6 +576,7 @@ class ABUtilAddonPrefs(bpy.types.AddonPreferences):
         if self.fbx_exporter_type == 'NATIVE':
             box.label(text = "Native FBX Export Preferences")
             box_naming = box.box()
+            box_naming.label(text = "Quick Export Name Collection")
             box_naming.label(text = "Include the following objects despite their viewport display type:")
             self.__draw_quick_export_names(box_naming)
             box.prop(self, "native_fbx_ex_scale_options")

--- a/ab_blender_utilities/addon/ab_prefs.py
+++ b/ab_blender_utilities/addon/ab_prefs.py
@@ -36,6 +36,26 @@ class PanelVars(bpy.types.PropertyGroup):
         default = 'SUBMENUS'
     )
 
+    quick_export_name_selection : bpy.props.IntProperty(
+        description = "If a part of a child object's name is contained in this list,\nit will always be selected when exporting objects"
+    )
+
+class ABUtilQuickExportNames(bpy.types.PropertyGroup):
+    arg_type : bpy.props.EnumProperty(
+        name = "Type",
+        items = ab_constants.e_string_find_action,
+        default = 'CONTAINS'
+    )
+
+class ABUTIL_UL_name_slots(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        split = layout.split(factor = 0.3)
+        split.prop(item, "name", icon = 'OBJECT_DATAMODE', emboss = False, text="")
+        split.prop(item, "arg_type")
+
+    def invoke(self, context, event):
+        pass
+
 class ABUtilAddonPrefs(bpy.types.AddonPreferences):
     bl_idname = __package__[:len(__package__)-6]
 
@@ -52,6 +72,11 @@ class ABUtilAddonPrefs(bpy.types.AddonPreferences):
     utilties_in_properties : bpy.props.BoolProperty(
         name = "Utilities in the properties panel",
         default = False
+    )
+
+    # Quick export collection property
+    quick_export_name_collection : bpy.props.CollectionProperty(
+        type = ABUtilQuickExportNames
     )
 
     # Sub-menu display
@@ -394,68 +419,80 @@ class ABUtilAddonPrefs(bpy.types.AddonPreferences):
         elif self.panel_vars_ptr.tabs == 'ADVANCED':
             self.__draw_advanced(box)
 
+    def __draw_quick_export_names(self, parent) -> None:
+        box = parent.box()
+
+        row = box.row()
+
+        row.template_list("ABUTIL_UL_name_slots", "", self, "quick_export_name_collection", self.panel_vars_ptr, "quick_export_name_selection", rows=5)
+
+        col = row.column(align=True)
+        col.operator("object.ab_add_remove_quick_export_name", icon='ADD', text="").arg = 'ADD'
+        col.operator("object.ab_add_remove_quick_export_name", icon='REMOVE', text="").arg = 'REMOVE'
+
+
     def __draw_submenu_buttons(self, parent) -> None:
-            box = parent.box()
-            box.label(text = "You can render a submenu as buttons in a pie menu by checking these boxes.")
-            box.label(text = "The parent of a submenu determines if it's rendered as buttons.")
+        box = parent.box()
+        box.label(text = "You can render a submenu as buttons in a pie menu by checking these boxes.")
+        box.label(text = "The parent of a submenu determines if it's rendered as buttons.")
 
-            parent.prop(self, "pie_menu_button_spacing_x")
-            parent.prop(self, "pie_menu_button_spacing_y")
+        parent.prop(self, "pie_menu_button_spacing_x")
+        parent.prop(self, "pie_menu_button_spacing_y")
 
-            parent.prop(self, "submenu_attributes_buttons")
-            parent.prop(self, "submenu_cleanup_buttons")
-            parent.prop(self, "submenu_colors_buttons")
-            parent.prop(self, "submenu_file_buttons")
-            parent.prop(self, "submenu_modifiers_buttons")
-            parent.prop(self, "submenu_naming_buttons")
-            parent.prop(self, "submenu_objects_buttons")
-            parent.prop(self, "submenu_point_cloud_buttons")
-            parent.prop(self, "submenu_selection_buttons")
-            parent.prop(self, "submenu_uvs_buttons")
-            parent.prop(self, "submenu_fbx_quick_export_buttons")
+        parent.prop(self, "submenu_attributes_buttons")
+        parent.prop(self, "submenu_cleanup_buttons")
+        parent.prop(self, "submenu_colors_buttons")
+        parent.prop(self, "submenu_file_buttons")
+        parent.prop(self, "submenu_modifiers_buttons")
+        parent.prop(self, "submenu_naming_buttons")
+        parent.prop(self, "submenu_objects_buttons")
+        parent.prop(self, "submenu_point_cloud_buttons")
+        parent.prop(self, "submenu_selection_buttons")
+        parent.prop(self, "submenu_uvs_buttons")
+        parent.prop(self, "submenu_fbx_quick_export_buttons")
 
     def __draw_panel_show(self, parent) -> None:
-            box = parent.box()
-            box.label(text = "You can include menus in a 3D Viewport panel.")
+        box = parent.box()
+        box.label(text = "You can include menus in a 3D Viewport panel.")
 
-            parent.prop(self, "panel_attributes_show")
-            parent.prop(self, "panel_cleanup_show")
-            parent.prop(self, "panel_colors_show")
-            parent.prop(self, "panel_file_show")
-            parent.prop(self, "panel_modifiers_show")
-            parent.prop(self, "panel_naming_show")
-            parent.prop(self, "panel_objects_show")
-            parent.prop(self, "panel_point_cloud_show")
-            parent.prop(self, "panel_selection_show")
-            parent.prop(self, "panel_uvs_show")
-            parent.prop(self, "panel_fbx_quick_export_show")
+        parent.prop(self, "panel_attributes_show")
+        parent.prop(self, "panel_cleanup_show")
+        parent.prop(self, "panel_colors_show")
+        parent.prop(self, "panel_file_show")
+        parent.prop(self, "panel_modifiers_show")
+        parent.prop(self, "panel_naming_show")
+        parent.prop(self, "panel_objects_show")
+        parent.prop(self, "panel_point_cloud_show")
+        parent.prop(self, "panel_selection_show")
+        parent.prop(self, "panel_uvs_show")
+        parent.prop(self, "panel_fbx_quick_export_show")
 
     def __draw_submenu_show(self, parent) -> None:
-            box = parent.box()
-            box.label(text = "You can exclude certain menus from appearing here.")
-            box.label(text = "Disabling the \"Attributes\" menu for example will instead render its first submenu")
-            box.label(text = " \"Colors\".")
+        box = parent.box()
+        box.label(text = "You can exclude certain menus from appearing here.")
+        box.label(text = "Disabling the \"Attributes\" menu for example will instead render its first submenu")
+        box.label(text = " \"Colors\".")
 
-            parent.prop(self, "submenu_attributes_show")
-            parent.prop(self, "submenu_cleanup_show")
-            parent.prop(self, "submenu_colors_show")
-            parent.prop(self, "submenu_file_show")
-            parent.prop(self, "submenu_modifiers_show")
-            parent.prop(self, "submenu_naming_show")
-            parent.prop(self, "submenu_objects_show")
-            parent.prop(self, "submenu_point_cloud_show")
-            parent.prop(self, "submenu_selection_show")
-            parent.prop(self, "submenu_uvs_show")
-            parent.prop(self, "submenu_fbx_quick_export_show")
+        parent.prop(self, "submenu_attributes_show")
+        parent.prop(self, "submenu_cleanup_show")
+        parent.prop(self, "submenu_colors_show")
+        parent.prop(self, "submenu_file_show")
+        parent.prop(self, "submenu_modifiers_show")
+        parent.prop(self, "submenu_naming_show")
+        parent.prop(self, "submenu_objects_show")
+        parent.prop(self, "submenu_point_cloud_show")
+        parent.prop(self, "submenu_selection_show")
+        parent.prop(self, "submenu_uvs_show")
+        parent.prop(self, "submenu_fbx_quick_export_show")
 
     def __draw_panels_in_props(self, parent) -> None:
-            box = parent.box()
-            box.label(text = "Adds panels to the properties panel.")
+        box = parent.box()
+        box.label(text = "Adds panels to the properties panel.")
 
-            parent.prop(self, "show_color_attribute_utils_in_properties")
-            parent.prop(self, "show_data_attribute_utils_in_properties")
-            parent.prop(self, "show_object_attribute_utils_in_properties")
-            parent.prop(self, "show_uv_attribute_utils_in_properties")
+        parent.prop(self, "show_color_attribute_utils_in_properties")
+        parent.prop(self, "show_data_attribute_utils_in_properties")
+        parent.prop(self, "show_object_attribute_utils_in_properties")
+        parent.prop(self, "show_uv_attribute_utils_in_properties")
 
     def __draw_advanced(self, parent) -> None:
         split = parent.split()
@@ -538,6 +575,9 @@ class ABUtilAddonPrefs(bpy.types.AddonPreferences):
         box = column.box()
         if self.fbx_exporter_type == 'NATIVE':
             box.label(text = "Native FBX Export Preferences")
+            box_naming = box.box()
+            box_naming.label(text = "Include the following objects despite their viewport display type:")
+            self.__draw_quick_export_names(box_naming)
             box.prop(self, "native_fbx_ex_scale_options")
             box.prop(self, "native_fbx_ex_mesh_smooth_type")
             box.prop(self, "native_fbx_ex_use_tspace")

--- a/ab_blender_utilities/lib/ab_common.py
+++ b/ab_blender_utilities/lib/ab_common.py
@@ -89,15 +89,53 @@ def get_selected_objects() -> tuple[bpy.types.Object]:
     """Returns an immutable list of selected objects."""
     return tuple(bpy.context.selected_objects)
 
-def select_child_objects(select_wire : bool = False) -> None:
-    """Selects all child objects in selected objects.\n
+def __select_child_objects(obj : bpy.types.Object,
+                           select_wire : bool = False,
+                           recursive : bool = False) -> None:
+    """Selects all child objects in the `obj` argument.\n
     The `select_wire` argument bypasses the `display_type` check."""
-    for obj in bpy.context.selected_objects:
-        for ch_obj in obj.children:
+    for ch_obj in obj.children:
             if ch_obj.display_type == 'TEXTURED'\
             or ch_obj.display_type == 'SOLID'\
             or select_wire:
                 ch_obj.select_set(True)
+                if len(ch_obj.children) > 0 and recursive:
+                    __select_child_objects(ch_obj, select_wire, recursive)
+
+def select_child_objects(select_wire : bool = False,
+                         recursive : bool = False,
+                         *,
+                         objects : bpy.types.Object = None) -> None:
+    """Selects all child objects in selected objects.\n
+    The `select_wire` argument bypasses the `display_type` check."""
+    if objects == None:
+        objects = bpy.context.selected_objects
+        
+    for obj in objects:
+        __select_child_objects(obj, select_wire, recursive)
+
+def get_child_objects(obj : bpy.types.Object,
+                      select_wire : bool = False,
+                      recursive : bool = False) -> list[bpy.types.Object]:
+    """Gets all child objects in the `obj` argument.\n
+    The `select_wire` argument bypasses the `display_type` check."""
+    children : list[bpy.types.Object] = []
+    for ch_obj in obj.children:
+            if ch_obj.display_type == 'TEXTURED'\
+            or ch_obj.display_type == 'SOLID'\
+            or select_wire:
+                children.append(ch_obj)
+                if len(ch_obj.children) > 0 and recursive:
+                    children += get_child_objects(ch_obj, select_wire, recursive)
+    return children
+        
+
+def select_objects(targets : list[bpy.types.Object] | tuple[bpy.types.Object]) -> None:
+    """Selects target objects."""
+    for obj in targets:
+        # Selection
+        if obj:
+            obj.select_set(True)
 
 def deselect_all() -> None:
     """Deselects all objects."""

--- a/ab_blender_utilities/lib/ab_json.py
+++ b/ab_blender_utilities/lib/ab_json.py
@@ -44,10 +44,12 @@ def dump_pc_data(data : list) -> str:
     for point in data:
         location : tuple(float) = getattr(point, "location")  # location
         rotation : tuple(float) = getattr(point, "rotation")  # rotation
+        scale : tuple(float) = getattr(point, "scale")  # scale
         asset_path : str = getattr(point, "asset_path") if len(getattr(point, "asset_path")) < 4096 else ""  # asset path
 
         point_data_d : dict = {"location" : location,
                                "rotation" : rotation,
+                               "scale" : scale,
                                "asset_path" : asset_path}
         
         point_cloud_d["point_cloud"].append(point_data_d)
@@ -68,9 +70,10 @@ def load_pc_data(json_data : str) -> list | None:
     for point in point_cloud_d["point_cloud"]:
         location : tuple = tuple(point["location"])
         rotation : tuple = tuple(point["rotation"])
+        scale : tuple = tuple(point["scale"])
         asset_path : str = point["asset_path"]
         
-        data.append((location, rotation, asset_path))
+        data.append((location, rotation, scale, asset_path))
     
     return data
     

--- a/ab_blender_utilities/lib/ab_naming_extra.py
+++ b/ab_blender_utilities/lib/ab_naming_extra.py
@@ -16,6 +16,7 @@
 
 import bpy
 import re
+from .ab_common import pad_index, get_child_objects
 
 def object_name_variables(obj : bpy.types.Object, value : str, index_str : str) -> str:
     # The existing name of the current object
@@ -55,3 +56,15 @@ def object_name_variables(obj : bpy.types.Object, value : str, index_str : str) 
                 print("Incorrect parameter")
             value = value.replace(replace_args[0], replace_args[1])
     return value
+
+def rename_child_objects(obj : bpy.types.Object,
+                         name: str,
+                         alias : str,
+                         rename_wireframe : bool,
+                         recursive : bool) -> None:
+    """Renames the `children` of the `obj` argument with the `name`, the index, and `alias`."""
+    children : list[bpy.types.Object] = get_child_objects(obj, rename_wireframe, recursive)
+    for i, ch_obj in enumerate(children):
+        ch_obj.name = f"{name}_pt{pad_index(i+1)}{alias}"
+        if ch_obj.data:
+            ch_obj.data.name = ch_obj.name

--- a/ab_blender_utilities/lib/ab_quick_export.py
+++ b/ab_blender_utilities/lib/ab_quick_export.py
@@ -34,3 +34,17 @@ def has_quick_export_path(scene : bpy.types.Scene = None) -> bool:
     except:
         return False
     
+def select_objects_from_name_collection(name_collection : bpy.props.CollectionProperty) -> None:
+    for obj in bpy.context.selected_objects:
+        for ch_obj in obj.children:
+                for name_item in name_collection:
+                    if name_item.arg_type == 'CONTAINS':
+                        if name_item.name in ch_obj.name:
+                            ch_obj.select_set(True)
+                    elif name_item.arg_type == 'BEGINS_WITH':
+                        if ch_obj.name.startswith(name_item.name):
+                            ch_obj.select_set(True)
+                    elif name_item.arg_type == 'ENDS_WITH':
+                        if ch_obj.name.endswith(name_item.name):
+                            ch_obj.select_set(True)
+    

--- a/ab_blender_utilities/operators/cleanup_ops.py
+++ b/ab_blender_utilities/operators/cleanup_ops.py
@@ -34,7 +34,9 @@ class OpABRemoveUnusedMaterialsOnSelected(bpy.types.Operator, CategoryCleanup):
     
     def execute(self, context):        
         for obj in bpy.context.selected_objects:
-            bpy.ops.object.material_slot_remove_unused({"object": obj})
+            if obj.data:
+                if hasattr(obj.data, "materials"):
+                    bpy.ops.object.material_slot_remove_unused({"object": obj})
 
         return {'FINISHED'}
     

--- a/ab_blender_utilities/operators/file_ops/file_ops_common.py
+++ b/ab_blender_utilities/operators/file_ops/file_ops_common.py
@@ -75,8 +75,9 @@ class OpABExportPointCloudFile(bpy.types.Operator, ExportHelper, CategoryFile):
             asset_path = ""
             if "asset_path" in obj:
                 asset_path = obj["asset_path"]
-            point = ab_json.PointCloudPoint(location = (obj.location.x, obj.location.y, obj.location.y),
+            point = ab_json.PointCloudPoint(location = (obj.location.x, obj.location.y, obj.location.z),
                                             rotation = (obj.rotation_euler.x, obj.rotation_euler.y, obj.rotation_euler.z),
+                                            scale = (obj.scale.x, obj.scale.y, obj.scale.z),
                                             asset_path = asset_path)
             
             data.append(point)
@@ -117,13 +118,15 @@ class OpABImportPointCloudFile(bpy.types.Operator, ImportHelper, CategoryFile):
                     for i, data_point in enumerate(data):
                         point_pos = mathutils.Vector(data_point[0])
                         point_rot = mathutils.Vector(data_point[1])
+                        point_scale = mathutils.Vector(data_point[2])
                         new_inst = bpy.data.objects.new("SMI_"+active_obj.name+"_{}".format(ab_common.pad_index(i+1)), 
                                                         active_obj.data)
                         bpy.context.collection.objects.link(new_inst)
                         new_inst.location = point_pos
                         new_inst.rotation_euler = point_rot
-                        if data_point[2] != "":
-                            new_inst["asset_path"] = data_point[2]
+                        new_inst.scale = point_scale
+                        if data_point[3] != "":
+                            new_inst["asset_path"] = data_point[3]
                 else:
                     ab_common.warning(self, "You need a \'MESH\' object select to instantiate")
                     return {'CANCELED'}

--- a/ab_blender_utilities/operators/global_ops.py
+++ b/ab_blender_utilities/operators/global_ops.py
@@ -20,7 +20,8 @@ These are not included in the dynamically filled menu.
 """
 import bpy
 from ..lib import ab_quick_export
-from ..addon import ab_keymaps
+from ..addon import ab_keymaps, ab_persistent
+from ..addon.ab_constants import e_add_remove
 
 
 class OpAbDeleteSceneQuickExportPaths(bpy.types.Operator):
@@ -45,5 +46,30 @@ class OpAbRestoreDefaultKeymaps(bpy.types.Operator):
         ab_keymaps.restore()
         return {'FINISHED'}
     
-OPERATORS : tuple[bpy.types.Operator] = (OpAbDeleteSceneQuickExportPaths,
+class OpAbAddRemoveQuickExportNames(bpy.types.Operator):
+    """Adds or removes quick export names"""
+    bl_idname = "object.ab_add_remove_quick_export_name"
+    bl_label = "Add/Remove Quick Export Names"
+    bl_description = "Adds or removes a string to a list in the plugin's properties."
+    bl_options = {'REGISTER'}
+
+    arg : bpy.props.EnumProperty(
+        items = e_add_remove
+        )
+    
+    def invoke(self, context, event):
+        prefs = ab_persistent.get_preferences()
+        if self.arg == "ADD":
+            name_entry = prefs.quick_export_name_collection.add()
+            name_entry.name = "Default"
+            name_entry.type = 1
+            return {'FINISHED'}
+        elif self.arg == "REMOVE":
+            entry_idx = prefs.panel_vars_ptr.quick_export_name_selection
+            prefs.panel_vars_ptr.quick_export_name_selection -=1
+            prefs.quick_export_name_collection.remove(entry_idx)
+            return {'FINISHED'}
+    
+OPERATORS : tuple[bpy.types.Operator] = (OpAbAddRemoveQuickExportNames,
+                                         OpAbDeleteSceneQuickExportPaths,
                                          OpAbRestoreDefaultKeymaps)

--- a/ab_blender_utilities/operators/naming_ops.py
+++ b/ab_blender_utilities/operators/naming_ops.py
@@ -30,21 +30,35 @@ class OpABObjectNamesFromParent(bpy.types.Operator, CategoryNaming):
     bl_idname = "wm.ab_object_names_from_parent"
     bl_label = "Object names from parent"
     bl_options = {'REGISTER', 'UNDO'}
+
+    recursive : bpy.props.BoolProperty(
+        name = "Recursive",
+        default = True
+    )
+
+    rename_wireframe : bpy.props.BoolProperty(
+        name = "Rename wireframe",
+        default = True,
+    )
+
+    bake_alias_after_idx : bpy.props.BoolProperty(
+        name = "Bake alias after index",
+        default = True,
+    )
     
     def execute(self, context):        
         for obj in bpy.context.selected_objects:
             # Selection
-            object_name = obj.name.split("/")
-            object_name = object_name[len(object_name)-1]
-            for alias in ab_constants.bake_alias:
-                if alias in object_name:
-                    object_name = object_name.split(alias)
-                    object_name[1] = alias
-                    break
-            for i, ch_obj in enumerate(obj.children):
-                ch_obj.name = object_name + "_pt" + ab_common.pad_index(i+1)
-                if ch_obj.data:
-                    ch_obj.data.name = ch_obj.name
+            obj_name_split : list = obj.name.split("/")
+            obj_name : str = obj_name_split[len(obj_name_split)-1]
+            obj_alias : str = ""
+            if self.bake_alias_after_idx:
+                for alias in ab_constants.bake_suffixes:
+                    if alias in obj_name:
+                        obj_alias = alias
+                        obj_name = obj_name.replace(alias, "")
+                        break
+            ab_naming_extra.rename_child_objects(obj, obj_name, obj_alias, self.recursive, self.rename_wireframe)
 
         return {'FINISHED'}
     

--- a/ab_blender_utilities/operators/selection_ops.py
+++ b/ab_blender_utilities/operators/selection_ops.py
@@ -23,25 +23,30 @@ class CategorySelection(ab_common.Category):
     category = "Selection"
     category_icon = 'RESTRICT_SELECT_OFF'
 
-class OpABSelectChildObjectsRecursive(bpy.types.Operator, CategorySelection):
-    """Selects all child objects"""
-    bl_idname = "object.ab_select_all_child_objects_recursive"
-    bl_label = "Select child objects (Recursive)"
+class OpABSelectChildObjects(bpy.types.Operator, CategorySelection):
+    """Selects all child objects.\nThis operator can select objects recursively"""
+    bl_idname = "object.ab_select_all_child_objects"
+    bl_label = "Select child objects"
     bl_options = {'REGISTER', 'UNDO'}
 
     category_arg = ab_common.OperatorCategories.SELECTION
+
+    recursive : bpy.props.BoolProperty(
+        name = "Recursive",
+        default = True
+    )
     
     select_wireframe : bpy.props.BoolProperty(
         name = "Select wireframe",
-        default = False,
+        default = True,
     )
 
     def execute(self, context):
-        ab_common.select_child_objects(self.select_wireframe)  
+        ab_common.select_child_objects(self.select_wireframe, self.recursive)  
         return {'FINISHED'}
     
 class OpABSaveSelection(bpy.types.Operator, CategorySelection):
-    """Saves the current selection, can be restorted using the \"Restore Selection\" operator."""
+    """Saves the current selection, can be restorted using the \"Restore Selection\" operator"""
     bl_idname = "object.ab_save_selection"
     bl_label = "Save Selection"
     bl_options = {'REGISTER', 'UNDO'}
@@ -53,7 +58,7 @@ class OpABSaveSelection(bpy.types.Operator, CategorySelection):
         return {'FINISHED'}
     
 class OpABRestoreSelection(bpy.types.Operator, CategorySelection):
-    """Restores a selection saved using the \"Save Selection\" operator."""
+    """Restores a selection saved using the \"Save Selection\" operator"""
     bl_idname = "object.ab_restore_selection"
     bl_label = "Restore Selection"
     bl_options = {'REGISTER', 'UNDO'}
@@ -69,7 +74,7 @@ class OpABRestoreSelection(bpy.types.Operator, CategorySelection):
         return {'FINISHED'}
     
 class OpABDeleteSavedSelection(bpy.types.Operator, CategorySelection):
-    """Restores a selection saved using the \"Save Selection\" operator."""
+    """Restores a selection saved using the \"Save Selection\" operator"""
     bl_idname = "object.ab_delete_saved_selection"
     bl_label = "Delete Saved Selection"
     bl_options = {'REGISTER', 'UNDO'}
@@ -84,7 +89,7 @@ class OpABDeleteSavedSelection(bpy.types.Operator, CategorySelection):
         ab_selection_saving.delete_saved_selection()
         return {'FINISHED'}
     
-OPERATORS : tuple[bpy.types.Operator] = (OpABSelectChildObjectsRecursive,
+OPERATORS : tuple[bpy.types.Operator] = (OpABSelectChildObjects,
                                          OpABSaveSelection,
                                          OpABRestoreSelection,
                                          OpABDeleteSavedSelection)


### PR DESCRIPTION
- An "Export Wired" checkbox has been added to the quick export operator for exporting objects with the "Wired" display type.
- The quick export operators now have a checkbox "Restore Selection". When on, the selection in the scene is the same as it was before running the operator. This functionality is on by default.
- Quick export now has a feature that allows the user to export wired objects that begin, end, or have an occurrence of a string in their name. This new name collection feature can be helpful when exporting collision objects with a mesh without having to tick "Export Wired" for quick exports. The "Quick Export Name Collection" feature is under the "Quick Export" tab in the addon properties.
- The "Remove unused materials" operator now checks if the object data has materials before removing a material.
- Added a missing reference to scale in the point cloud import and export operators.
- Fixed an incorrect reference to the z-axis in the point cloud export operator.
- Renamed the "Select child objects (Recursive)" operator to "Select child objects".
- The "Object names from parent" now has a "Bake alias after index" checkbox that, when on, places bake aliases after the part index.
- Added missing recursive object selection functionality to the "Select child objects" operator.
- Fixed an incorrect reference to bake suffixes in the "Object names from parent" operator.