### PR TITLE
v1.3.1 Update

### DIFF
--- a/ab_blender_utilities/__init__.py
+++ b/ab_blender_utilities/__init__.py
@@ -20,7 +20,7 @@ bl_info = {
     "author" : "Artemy belzer",
     "location" : "3D Viewport panels, the addon's pie menu (default keymap `Alt + E`), the Object menu, or the Object context menu.",
     "category" : "Utility",
-    "version" : (1, 3, 0)
+    "version" : (1, 3, 1)
 }
 
 if "core" in locals():

--- a/ab_blender_utilities/operators/naming_ops.py
+++ b/ab_blender_utilities/operators/naming_ops.py
@@ -123,7 +123,7 @@ class ABBU_OT_CustomExpressionObjRename(Operator, CatNaming):
             o.name += num_splitter + auto_index_str
 
         # Object data
-        if hasattr(o, "data") and self.rename_obj_data:
+        if o.data and self.rename_obj_data:
             if o.data.users > 1 and not self.update_multi_user_mesh_data:
                 return
             o.data.name = o.name


### PR DESCRIPTION
- Fixed a bug where the Custom Expression Object Rename operator did not correctly prevent a multi-user check on objects with no data, such as empties.